### PR TITLE
Ajuste na classe CSS imgText

### DIFF
--- a/tecnart/assets/css/style.css
+++ b/tecnart/assets/css/style.css
@@ -1726,9 +1726,14 @@ form input[type="submit"]:focus {
                               color: #ffffff;
                               font-family: 'PT Sans', sans-serif;
                               text-transform: uppercase;
-                              font-size: 23px;
+                              font-size: 21px;
                               text-align: center;
                               font-weight: 600;
+
+                              white-space: normal; 
+                              overflow: hidden; 
+                              line-height: 1.2em; 
+                             
                           }
                           
                           .qualquer {


### PR DESCRIPTION
Ajuste na classe css .imgText.m-auto para melhorar a legibilidade dos nomes dos investigadores.