### PR TITLE
Registo das visitas ao site, e o país de onde foi estabelecida a cone…

### DIFF
--- a/tecnart/colaboradores.php
+++ b/tecnart/colaboradores.php
@@ -7,6 +7,10 @@ include 'models/functions.php';
 //Ligação à base de dados
 
 $pdo = pdo_connect_mysql();
+
+//Registar visita
+registar_visita($pdo, "colaboradores.php");
+
 $language = ($_SESSION["lang"] == "en") ? "_en" : "";
 
 

--- a/tecnart/eixos.php
+++ b/tecnart/eixos.php
@@ -1,9 +1,15 @@
 <?php
+include 'config/dbconnection.php';
 include 'models/functions.php';
+$pdo = pdo_connect_mysql();
+
+registar_visita($pdo, "eixos.php");
 ?>
 
 
 <?= redirectPageLanguage("eixos.php","axes.php"); ?>
+
+
 
 
 <!DOCTYPE html>

--- a/tecnart/estrutura.php
+++ b/tecnart/estrutura.php
@@ -5,9 +5,9 @@ include 'models/functions.php';
 
 $pdo = pdo_connect_mysql();
 
+registar_visita($pdo, "estrutura.php");
 
 
-    $pdo = pdo_connect_mysql();
 
     $stmt = $pdo->prepare('SELECT * FROM conselho_consultivo');
     $stmt->execute();

--- a/tecnart/financiamento.php
+++ b/tecnart/financiamento.php
@@ -1,5 +1,10 @@
 <?php
+include 'config/dbconnection.php';
 include 'models/functions.php';
+
+$pdo = pdo_connect_mysql();
+
+registar_visita($pdo, "estrutura.php");
 ?>
 
 

--- a/tecnart/index.php
+++ b/tecnart/index.php
@@ -2,6 +2,7 @@
 include 'config/dbconnection.php';
 include 'models/functions.php';
 $pdo = pdo_connect_mysql();
+registar_visita($pdo, "index.php");
 $language = ($_SESSION["lang"] == "en") ? "_en" : "";
 ?>
 

--- a/tecnart/integrados.php
+++ b/tecnart/integrados.php
@@ -4,6 +4,10 @@ include 'models/functions.php';
 
 //ligação à base de dados
 $pdo = pdo_connect_mysql();
+
+//registar visita
+registar_visita($pdo, "integrados.php");
+
 $language = ($_SESSION["lang"] == "en") ? "_en" : "";
 
 $perPage = 9;

--- a/tecnart/missao.php
+++ b/tecnart/missao.php
@@ -1,5 +1,10 @@
 <?php
+include 'config/dbconnection.php';
 include 'models/functions.php';
+
+$pdo = pdo_connect_mysql();
+
+registar_visita($pdo, "missão.php");
 
 ?>
 

--- a/tecnart/noticia.php
+++ b/tecnart/noticia.php
@@ -4,6 +4,7 @@ include 'models/functions.php';
 
 $pdo = pdo_connect_mysql();
 
+
 $language = ($_SESSION["lang"] == "en") ? "_en" : "";
 $query = "SELECT id,
         COALESCE(NULLIF(titulo{$language}, ''), titulo) AS titulo,

--- a/tecnart/noticias.php
+++ b/tecnart/noticias.php
@@ -4,6 +4,8 @@ include 'models/functions.php';
 
 $pdo = pdo_connect_mysql();
 
+registar_visita($pdo, "noticias.php");
+
 $language = ($_SESSION["lang"] == "en") ? "_en" : "";
 
 //Paginação

--- a/tecnart/novasadmissoes.php
+++ b/tecnart/novasadmissoes.php
@@ -1,5 +1,10 @@
 <?php
+include 'config/dbconnection.php';
 include 'models/functions.php';
+
+$pdo = pdo_connect_mysql();
+
+registar_visita($pdo, "novasadmissoes.php");
 ?>
 
 <?= redirectPageLanguage("novasadmissoes.php","new_admissions.php"); ?>

--- a/tecnart/oportunidades.php
+++ b/tecnart/oportunidades.php
@@ -4,6 +4,9 @@ include 'models/functions.php';
 
 
 $pdo = pdo_connect_mysql();
+
+registar_visita($pdo, "oportunidades.php");
+
 $language = ($_SESSION["lang"] == "en") ? "_en" : "";
 
 $query = "SELECT id,COALESCE(NULLIF(titulo{$language}, ''), titulo) AS titulo,visivel,imagem FROM oportunidades WHERE visivel=true ORDER BY ID DESC";

--- a/tecnart/projetos_concluidos.php
+++ b/tecnart/projetos_concluidos.php
@@ -4,6 +4,10 @@ include 'models/functions.php';
 
 //ligação à base de dados
 $pdo = pdo_connect_mysql();
+
+//registar visita
+registar_visita($pdo, "projetos_concluidos.php");
+
 $language = ($_SESSION["lang"] == "en") ? "_en" : "";
 
 

--- a/tecnart/projetos_em_curso.php
+++ b/tecnart/projetos_em_curso.php
@@ -4,6 +4,10 @@ include 'models/functions.php';
 
 //ligação à base de dados
 $pdo = pdo_connect_mysql();
+
+//registar visita
+registar_visita($pdo, "projetos_em_curso.php");
+
 $language = ($_SESSION["lang"] == "en") ? "_en" : "";
 
 $perPage = 9;

--- a/tecnart/publicacoes.php
+++ b/tecnart/publicacoes.php
@@ -2,6 +2,10 @@
 include 'config/dbconnection.php';
 include 'models/functions.php';
 
+$pdo = pdo_connect_mysql();
+
+registar_visita($pdo, "publicacoes.php");
+
 ?>
 
 <?= redirectPageLanguage("publicacoes.php","publications.php"); ?>


### PR DESCRIPTION
…xãoda a conexão

- Para se conseguir registar as visitas ao site e o país de onde se acedeu, foram usadas duas funções, uma que serve para se obter o nome do país de onde foi feito o acesso ao site (através do IP público) através de uma API e a outra função serve para fazer as inserções nas tabelas tanto na tabela "país" como na tabela "acessos".
- A primeira função é chamada no interior da segunda, ou seja, a função para se obter o país é chamada no interior da função para se fazer a inserção na BD.